### PR TITLE
Potential fix for code scanning alert no. 28: Uncontrolled data used in path expression

### DIFF
--- a/router.js
+++ b/router.js
@@ -449,11 +449,19 @@ app.post('/render/:item', bodyParser.json(), async(req, res) => {
     debug(`POST render/${req.params.item} (${req.headers['user-agent']})`);
     const item = req.params.item;
     try {
-        const file = `./routes/render/${item}.js`;
+        const baseDir = path.resolve(__dirname, './routes/render');
+        const file = path.resolve(baseDir, `${item}.js`);
+
+        // Ensure the resolved path is within the intended directory
+        if (!file.startsWith(baseDir)) {
+            res.status(400).send('Invalid item parameter');
+            return;
+        }
+
         const checksPassed = await onReqChecks(req, res, file);
         debug(`Checks passed: ${checksPassed}`);
         if (!checksPassed) return;
-        const route = require(`./routes/render/${item}.js`);
+        const route = require(file);
         const executingAt = Date.now();
         debug(`Executing route`);
         await route(req, res);


### PR DESCRIPTION
Potential fix for [https://github.com/DaalBot/API/security/code-scanning/28](https://github.com/DaalBot/API/security/code-scanning/28)

To fix the issue, we need to validate the `item` parameter to ensure it only allows safe and expected values. A common approach is to use an allowlist of valid filenames or sanitize the input to remove any potentially harmful characters. Additionally, we can use `path.resolve` to normalize the path and ensure it remains within the intended directory.

The best fix for this case is to:
1. Normalize the constructed path using `path.resolve`.
2. Verify that the resolved path starts with the intended base directory (`./routes/render/`).
3. Optionally, use a regular expression or allowlist to further restrict the `item` parameter to expected values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
